### PR TITLE
Add zv after markdownfmt

### DIFF
--- a/autoload/markdownfmt.vim
+++ b/autoload/markdownfmt.vim
@@ -101,6 +101,7 @@ function! markdownfmt#Format()
 
     " restore our cursor/windows positions
     call winrestview(l:curw)
+    norm zv
 endfunction
 
 " vim:ts=4:sw=4:et


### PR DESCRIPTION
When you use folding based on syntax, all folds will be closed when you open a file. Many other plugins use zv to "Open just enough folds to make the line in which the cursor is located not folded.", including gofmt.